### PR TITLE
declare compatible to shell version 3.18

### DIFF
--- a/CoverflowAltTab@dmo60.de/metadata.json
+++ b/CoverflowAltTab@dmo60.de/metadata.json
@@ -1,6 +1,6 @@
 {
     "cinnamon-version": ["1.2", "1.4", "1.6", "1.8", "1.9", "2.0", "2.1", "2.2", "2.3", "2.4"],
-    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16"],
+    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18"],
     "uuid": "CoverflowAltTab@dmo60.de",
     "name": "Coverflow Alt-Tab",
     "description": "Replacement of Alt-Tab, iterates through windows in a cover-flow manner.",


### PR DESCRIPTION
Despite some errors reported in #45, adding the recently released version to the metadata.json makes it work just fine on my Arch Linux installation, so you may consider this simple update while working out further hiccups.