### PR TITLE
Support for Gnome 3.20

### DIFF
--- a/CoverflowAltTab@dmo60.de/metadata.json
+++ b/CoverflowAltTab@dmo60.de/metadata.json
@@ -1,6 +1,6 @@
 {
     "cinnamon-version": ["1.2", "1.4", "1.6", "1.8", "1.9", "2.0", "2.1", "2.2", "2.3", "2.4"],
-    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18"],
+    "shell-version": ["3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18", "3.20"],
     "uuid": "CoverflowAltTab@dmo60.de",
     "name": "Coverflow Alt-Tab",
     "description": "Replacement of Alt-Tab, iterates through windows in a cover-flow manner.",


### PR DESCRIPTION
[Gnome 3.20 was released](https://www.gnome.org/news/2016/03/gnome-3-20-released/) yesterday.
I just tested and this extension works fine under Gnome 3.20!