### PR TITLE
Gnome-Shell: Hide dash(e.g. Dash to Dock) and Legacy Tray in the Coverflow

### DIFF
--- a/CoverflowAltTab@dmo60.de/switcher.js
+++ b/CoverflowAltTab@dmo60.de/switcher.js
@@ -108,6 +108,10 @@ Switcher.prototype = {
             }, this);
         }
 
+        // hide gnome-shell legacy tray
+        if(Main.legacyTray)
+            Main.legacyTray.actor.hide();
+
         this._manager.platform.dimBackground();
         
         this._initialDelayTimeoutId = 0;
@@ -494,6 +498,10 @@ Switcher.prototype = {
             }
             panels.forEach(function(panel) { panel.actor.set_reactive(true); });
 
+            // show gnome-shell legacy tray
+            if(Main.legacyTray)
+                Main.legacyTray.actor.show();
+
             this._manager.platform.undimBackground(Lang.bind(this, this._onHideBackgroundCompleted));
             this._disableMonitorFix();
         }
@@ -523,6 +531,9 @@ Switcher.prototype = {
         let panels = [Main.panel];
         if(Main.panel2)
             panels.push(Main.panel2);
+        // gnome-shell dash
+        if(Main.overview._dash)
+            panels.push(Main.overview._dash);
         return panels;
     },
 


### PR DESCRIPTION
When the Dash to Dock is always visible it appears in Coverflow. But when the option to "hide-panel" is active, is preferred to hide the Dash to Dock.

When you hide the Dash to Dock is necessary to hide the Legacy Tray too, or it will appear in the middle of Coverflow.

This commit hides the Dash to Dock and the Legacy Tray in the Coverflow.