### PR TITLE
Declare compatible to gnome-shell version 3.32

### DIFF
--- a/CoverflowAltTab@dmo60.de/metadata.json
+++ b/CoverflowAltTab@dmo60.de/metadata.json
@@ -16,7 +16,8 @@
 	      "3.2"
     ],
     "shell-version": [
-        "3.30"
+        "3.30",
+        "3.32"
     ],
     "dangerous": false,
     "name": "Coverflow Alt-Tab",

--- a/CoverflowAltTab@palatis.blogspot.com/metadata.json
+++ b/CoverflowAltTab@palatis.blogspot.com/metadata.json
@@ -1,6 +1,6 @@
 {
     "cinnamon-version": ["1.2", "1.4", "1.6", "1.8", "1.9", "2.0", "2.1", "2.2", "2.3", "2.4", "2.8", "3.0"],
-    "shell-version": ["3.30"],
+    "shell-version": ["3.30", "3.32"],
     "uuid": "CoverflowAltTab@palatis.blogspot.com",
     "name": "Coverflow Alt-Tab",
     "description": "Replacement of Alt-Tab, iterates through windows in a cover-flow manner.",


### PR DESCRIPTION
As already mentioned in #95, Coverflow should work with the recent gnome-shell version. As the maintainer of a package for this extension in the [Arch Linux User Repository](https://aur.archlinux.org/packages/gnome-shell-extension-coverflow-alt-tab/), I tried it out on a current install. As far as I can tell, everything seems to work just fine, although I could not yet test multi-monitor support.

I propose also tagging a new release after the merge of this request so that the change propagates to all users of the packaged version.