### PR TITLE
Fix compatibility with GNOME3.34

### DIFF
--- a/CoverflowAltTab@dmo60.de/coverflowSwitcher.js
+++ b/CoverflowAltTab@dmo60.de/coverflowSwitcher.js
@@ -72,7 +72,12 @@ Switcher.prototype = {
             let compositor = this._windows[i].get_compositor_private();
             if (compositor) {
                 let texture = compositor.get_texture();
-                let [width, height] = texture.get_size();
+                let width, height
+                if (texture.get_size) {
+                    [width, height] = texture.get_size()
+                } else {
+                    [_, width, height] = texture.get_preferred_size();
+                }
 
                 let scale = 1.0;
                 let previewWidth = monitor.width * PREVIEW_SCALE;
@@ -82,7 +87,7 @@ Switcher.prototype = {
 
                 let clone = new Clutter.Clone({
                     opacity: (!metaWin.minimized && metaWin.get_workspace() == currentWorkspace || metaWin.is_on_all_workspaces()) ? 255 : 0,
-                    source: texture,
+                    source: texture.get_size ? texture : compositor,
                     reactive: true,
                     anchor_gravity: Clutter.Gravity.CENTER,
                     x: ((metaWin.minimized) ? 0 : compositor.x + compositor.width / 2) - monitor.x,

--- a/CoverflowAltTab@dmo60.de/coverflowSwitcher.js
+++ b/CoverflowAltTab@dmo60.de/coverflowSwitcher.js
@@ -76,7 +76,8 @@ Switcher.prototype = {
                 if (texture.get_size) {
                     [width, height] = texture.get_size()
                 } else {
-                    [_, width, height] = texture.get_preferred_size();
+                    let preferred_size_ok
+                    [preferred_size_ok, width, height] = texture.get_preferred_size();
                 }
 
                 let scale = 1.0;

--- a/CoverflowAltTab@dmo60.de/timelineSwitcher.js
+++ b/CoverflowAltTab@dmo60.de/timelineSwitcher.js
@@ -60,7 +60,12 @@ Switcher.prototype = {
             let compositor = this._windows[i].get_compositor_private();
             if (compositor) {
                 let texture = compositor.get_texture();
-                let [_, width, height] = texture.get_preferred_size();
+                let width, height
+                if (texture.get_size) {
+                    [width, height] = texture.get_size()
+                } else {
+                    [_, width, height] = texture.get_preferred_size();
+                }
 
                 let scale = 1.0;
                 let previewWidth = monitor.width * PREVIEW_SCALE;
@@ -70,7 +75,7 @@ Switcher.prototype = {
 
                 let clone = new Clutter.Clone({
                     opacity: (!metaWin.minimized && metaWin.get_workspace() == currentWorkspace || metaWin.is_on_all_workspaces()) ? 255 : 0,
-                    source: compositor,
+                    source: texture.get_size ? texture : compositor,
                     reactive: true,
                     anchor_gravity: Clutter.Gravity.WEST,
                     rotation_angle_y: 12,

--- a/CoverflowAltTab@dmo60.de/timelineSwitcher.js
+++ b/CoverflowAltTab@dmo60.de/timelineSwitcher.js
@@ -60,7 +60,7 @@ Switcher.prototype = {
             let compositor = this._windows[i].get_compositor_private();
             if (compositor) {
                 let texture = compositor.get_texture();
-                let [width, height] = texture.get_size();
+                let [_, width, height] = texture.get_preferred_size();
 
                 let scale = 1.0;
                 let previewWidth = monitor.width * PREVIEW_SCALE;
@@ -70,7 +70,7 @@ Switcher.prototype = {
 
                 let clone = new Clutter.Clone({
                     opacity: (!metaWin.minimized && metaWin.get_workspace() == currentWorkspace || metaWin.is_on_all_workspaces()) ? 255 : 0,
-                    source: texture,
+                    source: compositor,
                     reactive: true,
                     anchor_gravity: Clutter.Gravity.WEST,
                     rotation_angle_y: 12,

--- a/CoverflowAltTab@dmo60.de/timelineSwitcher.js
+++ b/CoverflowAltTab@dmo60.de/timelineSwitcher.js
@@ -64,7 +64,8 @@ Switcher.prototype = {
                 if (texture.get_size) {
                     [width, height] = texture.get_size()
                 } else {
-                    [_, width, height] = texture.get_preferred_size();
+                    let preferred_size_ok
+                    [preferred_size_ok, width, height] = texture.get_preferred_size();
                 }
 
                 let scale = 1.0;


### PR DESCRIPTION
This probably requires some testing.

----

MetaShapedTexture is now a subclass of Clutter.Content and thus is no longer an actor. Also, get_size() function is now gone so use get_preferred_size() (which returns a boolean and two ints).

Fixes #106 on my machine (Arch Linux, GNOME & Mutter 3.34 with some performance patches)