### PR TITLE
Replace panel.actor calls to silence the deprecation notices

### DIFF
--- a/CoverflowAltTab@dmo60.de/switcher.js
+++ b/CoverflowAltTab@dmo60.de/switcher.js
@@ -117,9 +117,10 @@ Switcher.prototype = {
         let panels = this.getPanels();
         panels.forEach(function(panel) {
             try {
-                panel.actor.set_reactive(false);
+                let panelActor = (panel instanceof Clutter.Actor) ? panel : panel.actor
+                panelActor.set_reactive(false);
                 if (this._settings.hide_panel) {
-                    Tweener.addTween(panel.actor, {
+                    Tweener.addTween(panelActor, {
                         opacity: 0,
                         time: this._settings.animation_time,
                         transition: TRANSITION_TYPE
@@ -508,10 +509,11 @@ Switcher.prototype = {
             let panels = this.getPanels();
             panels.forEach(function(panel) {
                 try {
-                    panel.actor.set_reactive(true);
+                    let panelActor = (panel instanceof Clutter.Actor) ? panel : panel.actor
+                    panelActor.set_reactive(true);
                     if (this._settings.hide_panel) {
-                        Tweener.removeTweens(panel.actor);
-                        Tweener.addTween(panel.actor, {
+                        Tweener.removeTweens(panelActor);
+                        Tweener.addTween(panelActor, {
                             opacity: 255,
                             time: this._settings.animation_time,
                             transition: TRANSITION_TYPE}


### PR DESCRIPTION
As with the previous PR, please check whether the commit suppresses all of the `Usage of object.actor is deprecated for Panel` (example message in #108).