### PR TITLE
Import Graphene only when necessary (shell version >= 3.36)

### DIFF
--- a/CoverflowAltTab@dmo60.de/coverflowSwitcher.js
+++ b/CoverflowAltTab@dmo60.de/coverflowSwitcher.js
@@ -24,8 +24,11 @@ const Lang = imports.lang;
 const Config = imports.misc.config;
 
 const Clutter = imports.gi.Clutter;
-const Graphene = imports.gi.Graphene;
 const Tweener = imports.ui.tweener;
+
+let Graphene;
+if (Config.PACKAGE_VERSION >= '3.36')
+    Graphene = imports.gi.Graphene;
 
 let ExtensionImports;
 if(Config.PACKAGE_NAME == 'cinnamon')

--- a/CoverflowAltTab@dmo60.de/switcher.js
+++ b/CoverflowAltTab@dmo60.de/switcher.js
@@ -24,13 +24,16 @@ const Lang = imports.lang;
 
 const Clutter = imports.gi.Clutter;
 const Config = imports.misc.config;
-const Graphene = imports.gi.Graphene;
 const St = imports.gi.St;
 const Meta = imports.gi.Meta;
 const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
 const Tweener = imports.ui.tweener;
 const Pango = imports.gi.Pango;
+
+let Graphene;
+if (Config.PACKAGE_VERSION >= '3.36')
+    Graphene = imports.gi.Graphene;
 
 const INITIAL_DELAY_TIMEOUT = 150;
 const CHECK_DESTROYED_TIMEOUT = 100;


### PR DESCRIPTION
While this didn't break my 3.36 install, I can't verify it works on 3.34 (where Graphene wasn't a dependency of Mutter), which is the version affected.

Should fix #123 .