### PR TITLE
Fix compatibility with GNOME Shell 3.37 (tweening)

### DIFF
--- a/CoverflowAltTab@dmo60.de/coverflowSwitcher.js
+++ b/CoverflowAltTab@dmo60.de/coverflowSwitcher.js
@@ -24,7 +24,6 @@ const Lang = imports.lang;
 const Config = imports.misc.config;
 
 const Clutter = imports.gi.Clutter;
-const Tweener = imports.ui.tweener;
 
 let ExtensionImports;
 if (Config.PACKAGE_NAME === "cinnamon") {
@@ -53,20 +52,17 @@ function appendParams(base, extra) {
     }
 }
 
-class CoverflowSwitcher extends BaseSwitcher
-{
-    constructor(...args)
-    {
+class CoverflowSwitcher extends BaseSwitcher {
+    constructor(...args) {
         super(...args);
 
         if (this._settings.elastic_mode)
-        	TRANSITION_TYPE = 'easeOutBack';
+            TRANSITION_TYPE = 'easeOutBack';
         else
-        	TRANSITION_TYPE = 'easeOutCubic';
+            TRANSITION_TYPE = 'easeOutCubic';
     }
 
-    _createPreviews()
-    {
+    _createPreviews() {
         // TODO: Shouldn't monitor be set once per coverflow state?
         let monitor = this._updateActiveMonitor();
         let currentWorkspace = this._manager.workspace_manager.get_active_workspace();
@@ -131,8 +127,7 @@ class CoverflowSwitcher extends BaseSwitcher
         }
     }
 
-    _previewNext()
-    {
+    _previewNext() {
         if (this._currentIndex == this._windows.length - 1) {
             this._currentIndex = 0;
             this._flipStack(Direction.TO_LEFT);
@@ -143,8 +138,7 @@ class CoverflowSwitcher extends BaseSwitcher
         TRANSITION_TYPE = 'easeOutCubic';
     }
 
-    _previewPrevious()
-    {
+    _previewPrevious() {
         if (this._currentIndex == 0) {
             this._currentIndex = this._windows.length - 1;
             this._flipStack(Direction.TO_RIGHT);
@@ -154,8 +148,7 @@ class CoverflowSwitcher extends BaseSwitcher
         }
     }
 
-    _flipStack(direction)
-    {
+    _flipStack(direction) {
         this._looping = true;
 
         let xOffset, angle;
@@ -169,7 +162,7 @@ class CoverflowSwitcher extends BaseSwitcher
             angle = -BLEND_OUT_ANGLE;
         }
 
-        let animation_time = this._settings.animation_time * 2/3;
+        let animation_time = this._settings.animation_time * 2 / 3;
 
         for (let [i, preview] of this._previews.entries()) {
             preview._cfIsLast = (i === this._windows.length - 1);
@@ -185,8 +178,7 @@ class CoverflowSwitcher extends BaseSwitcher
         }
     }
 
-    _onFlipIn(preview, index, direction)
-    {
+    _onFlipIn(preview, index, direction) {
         let xOffsetStart, xOffsetEnd, angleStart, angleEnd;
         this._updateActiveMonitor();
 
@@ -202,7 +194,7 @@ class CoverflowSwitcher extends BaseSwitcher
             angleEnd = SIDE_ANGLE;
         }
 
-        let animation_time = this._settings.animation_time * 2/3;
+        let animation_time = this._settings.animation_time * 2 / 3;
 
         if (direction === Direction.TO_RIGHT) {
             preview.translation_x = xOffsetStart - (this._previewsCenterPosition.x
@@ -220,7 +212,7 @@ class CoverflowSwitcher extends BaseSwitcher
         };
 
         if (index == this._currentIndex) {
-        	preview.make_top_layer(this.previewActor);
+            preview.make_top_layer(this.previewActor);
             let extraParams = preview._cfIsLast ? lastExtraParams : null;
             this._animatePreviewToMid(preview, animation_time, extraParams);
         } else {
@@ -244,8 +236,7 @@ class CoverflowSwitcher extends BaseSwitcher
         }
     }
 
-    _onFlipComplete(direction)
-    {
+    _onFlipComplete(direction) {
         this._looping = false;
         if (this._requiresUpdate === true) {
             this._requiresUpdate = false;
@@ -254,8 +245,7 @@ class CoverflowSwitcher extends BaseSwitcher
     }
 
     // TODO: Remove unused direction variable
-    _animatePreviewToMid(preview, animation_time, extraParams = [])
-    {
+    _animatePreviewToMid(preview, animation_time, extraParams = []) {
         preview.make_top_layer(this.previewActor);
 
         let tweenParams = {
@@ -276,11 +266,10 @@ class CoverflowSwitcher extends BaseSwitcher
         };
 
         appendParams(tweenParams, extraParams);
-        Tweener.addTween(preview, tweenParams);
+        this._manager.platform.tween(preview, tweenParams);
     }
 
-    _animatePreviewToSide(preview, index, xOffset, extraParams, toChangePivotPoint = true)
-    {
+    _animatePreviewToSide(preview, index, xOffset, extraParams, toChangePivotPoint = true) {
         if (toChangePivotPoint) {
             if (index < this._currentIndex) {
                 preview.set_pivot_point_placement(Placement.LEFT);
@@ -308,11 +297,10 @@ class CoverflowSwitcher extends BaseSwitcher
         }
 
         appendParams(tweenParams, extraParams);
-        Tweener.addTween(preview, tweenParams);
+        this._manager.platform.tween(preview, tweenParams);
     }
 
-    _updatePreviews()
-    {
+    _updatePreviews() {
         if (this._looping) {
             this._requiresUpdate = true;
             return;

--- a/CoverflowAltTab@dmo60.de/platform.js
+++ b/CoverflowAltTab@dmo60.de/platform.js
@@ -28,6 +28,7 @@ const Gio = imports.gi.Gio;
 const Config = imports.misc.config;
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
+const Clutter = imports.gi.Clutter;
 
 let Tweener = null;
 if (Config.PACKAGE_NAME == 'cinnamon' || Config.PACKAGE_VERSION <= "3.37") {
@@ -367,6 +368,29 @@ class PlatformGnomeShell extends AbstractPlatform {
             return Tweener.addTween(actor, params);
         }
 
+        switch (params.transition) {
+            case "easeOutBack":
+                params.mode = Clutter.AnimationMode.EASE_OUT_BACK;
+                break;
+            case "easeOutCubic":
+                params.mode = Clutter.AnimationMode.EASE_OUT_CUBIC;
+                break;
+            case "easeOutQuad":
+                params.mode = Clutter.AnimationMode.EASE_OUT_QUAD;
+                break;
+        }
+
+        if (params.onComplete) {
+            if (params.onCompleteParams && params.onCompleteScope) {
+                params.onComplete = params.onComplete.bind(params.onCompleteScope, ...params.onCompleteParams);
+            } else if (params.onCompleteParams) {
+                params.onComplete = params.onComplete.bind(null, params.onCompleteParams);
+            } else if (params.onCompleteScope) {
+                params.onComplete = params.onComplete.bind(params.onCompleteScope);
+            }
+        }
+
+        params.duration = params.time * 1000;
         actor.ease(params);
     }
 

--- a/CoverflowAltTab@dmo60.de/switcher.js
+++ b/CoverflowAltTab@dmo60.de/switcher.js
@@ -28,7 +28,6 @@ const St = imports.gi.St;
 const Meta = imports.gi.Meta;
 const Mainloop = imports.mainloop;
 const Main = imports.ui.main;
-const Tweener = imports.ui.tweener;
 const Pango = imports.gi.Pango;
 
 const INITIAL_DELAY_TIMEOUT = 150;
@@ -131,7 +130,7 @@ class Switcher
                 let panelActor = (panel instanceof Clutter.Actor) ? panel : panel.actor;
                 panelActor.set_reactive(false);
                 if (this._settings.hide_panel) {
-                    Tweener.addTween(panelActor, {
+                    this._manager.platform.tween(panelActor, {
                         opacity: 0,
                         time: this._settings.animation_time,
                         transition: TRANSITION_TYPE
@@ -228,7 +227,7 @@ class Switcher
 
         // window title label
         if (this._windowTitle) {
-            Tweener.addTween(this._windowTitle, {
+            this._manager.platform.tween(this._windowTitle, {
                 opacity: 0,
                 time: animation_time,
                 transition: TRANSITION_TYPE,
@@ -247,7 +246,7 @@ class Switcher
         this._windowTitle.clutter_text.ellipsize = Pango.EllipsizeMode.END;
 
         this.actor.add_actor(this._windowTitle);
-        Tweener.addTween(this._windowTitle, {
+        this._manager.platform.tween(this._windowTitle, {
             opacity: 255,
             time: animation_time,
             transition: TRANSITION_TYPE,
@@ -261,7 +260,7 @@ class Switcher
 
         // window icon
         if (this._applicationIconBox) {
-            Tweener.addTween(this._applicationIconBox, {
+            this._manager.platform.tween(this._applicationIconBox, {
                 opacity: 0,
                 time: animation_time,
                 transition: TRANSITION_TYPE,
@@ -299,7 +298,7 @@ class Switcher
 
         this._applicationIconBox.add_actor(this._icon);
         this.actor.add_actor(this._applicationIconBox);
-        Tweener.addTween(this._applicationIconBox, {
+        this._manager.platform.tween(this._applicationIconBox, {
             opacity: 255,
             time: animation_time,
             transition: TRANSITION_TYPE,
@@ -512,7 +511,7 @@ class Switcher
                     preview.make_bottom_layer(this.previewActor);
                 }
 
-                Tweener.addTween(preview, {
+                this._manager.platform.tween(preview, {
                     opacity: (!metaWin.minimized && metaWin.get_workspace() == currentWorkspace
                         || metaWin.is_on_all_workspaces()) ? 255 : 0,
 
@@ -542,8 +541,8 @@ class Switcher
                     let panelActor = (panel instanceof Clutter.Actor) ? panel : panel.actor;
                     panelActor.set_reactive(true);
                     if (this._settings.hide_panel) {
-                        Tweener.removeTweens(panelActor);
-                        Tweener.addTween(panelActor, {
+                        this._manager.platform.removeTweens(panelActor);
+                        this._manager.platform.tween(panelActor, {
                             opacity: 255,
                             time: this._settings.animation_time,
                             transition: TRANSITION_TYPE}

--- a/CoverflowAltTab@dmo60.de/timelineSwitcher.js
+++ b/CoverflowAltTab@dmo60.de/timelineSwitcher.js
@@ -24,7 +24,6 @@ const Lang = imports.lang;
 const Config = imports.misc.config;
 
 const Clutter = imports.gi.Clutter;
-const Tweener = imports.ui.tweener;
 
 let ExtensionImports;
 if (Config.PACKAGE_NAME === "cinnamon") {
@@ -45,20 +44,17 @@ const {
 let TRANSITION_TYPE;
 const PREVIEW_SCALE = 0.5;
 
-class TimelineSwitcher extends BaseSwitcher
-{
-    constructor(...args)
-    {
+class TimelineSwitcher extends BaseSwitcher {
+    constructor(...args) {
         super(...args);
 
         if (this._settings.elastic_mode)
-        	TRANSITION_TYPE = 'easeOutBack';
+            TRANSITION_TYPE = 'easeOutBack';
         else
-        	TRANSITION_TYPE = 'easeOutCubic';
+            TRANSITION_TYPE = 'easeOutCubic';
     }
 
-    _createPreviews()
-    {
+    _createPreviews() {
         let monitor = this._updateActiveMonitor();
         let currentWorkspace = this._manager.workspace_manager.get_active_workspace();
 
@@ -73,7 +69,7 @@ class TimelineSwitcher extends BaseSwitcher
                 let texture = compositor.get_texture();
                 let width, height;
                 if (texture.get_size) {
-                    [width, height] = texture.get_size()
+                    [width, height] = texture.get_size();
                 } else {
                     let preferred_size_ok;
                     [preferred_size_ok, width, height] = texture.get_preferred_size();
@@ -100,7 +96,7 @@ class TimelineSwitcher extends BaseSwitcher
 
                 preview.target_width = Math.round(width * scale);
                 preview.target_height = Math.round(height * scale);
-                preview.target_width_side = preview.target_width * 2/3;
+                preview.target_width_side = preview.target_width * 2 / 3;
                 preview.target_height_side = preview.target_height;
 
                 preview.target_x = findUpperLeftFromCenter(preview.target_width,
@@ -118,21 +114,18 @@ class TimelineSwitcher extends BaseSwitcher
         }
     }
 
-    _previewNext()
-    {
+    _previewNext() {
         this._currentIndex = (this._currentIndex + 1) % this._windows.length;
         this._updatePreviews(1);
         TRANSITION_TYPE = 'easeOutCubic';
     }
 
-    _previewPrevious()
-    {
+    _previewPrevious() {
         this._currentIndex = (this._windows.length + this._currentIndex - 1) % this._windows.length;
         this._updatePreviews(-1);
     }
 
-    _updatePreviews(direction)
-    {
+    _updatePreviews(direction) {
         if (this._previews.length == 0)
             return;
 
@@ -141,7 +134,7 @@ class TimelineSwitcher extends BaseSwitcher
 
         if (this._previews.length == 1) {
             let preview = this._previews[0];
-            Tweener.addTween(preview, {
+            this._manager.platform.tween(preview, {
                 opacity: 255,
                 x: preview.target_x,
                 y: preview.target_y,
@@ -159,7 +152,7 @@ class TimelineSwitcher extends BaseSwitcher
 
             if (distance === this._previews.length - 1 && direction > 0) {
                 preview.__looping = true;
-                Tweener.addTween(preview, {
+                this._manager.platform.tween(preview, {
                     opacity: 0,
                     x: preview.target_x + 200,
                     y: preview.target_y + 100,
@@ -173,7 +166,7 @@ class TimelineSwitcher extends BaseSwitcher
                 });
             } else if (distance === 0 && direction < 0) {
                 preview.__looping = true;
-                Tweener.addTween(preview, {
+                this._manager.platform.tween(preview, {
                     opacity: 0,
                     time: animation_time / 2,
                     transition: TRANSITION_TYPE,
@@ -194,22 +187,21 @@ class TimelineSwitcher extends BaseSwitcher
                 if (preview.__looping || preview.__finalTween)
                     preview.__finalTween = tweenparams;
                 else
-                    Tweener.addTween(preview, tweenparams);
+                    this._manager.platform.tween(preview, tweenparams);
             }
         }
     }
 
-    _onFadeBackwardsComplete(preview, distance, animation_time)
-    {
+    _onFadeBackwardsComplete(preview, distance, animation_time) {
         preview.__looping = false;
         preview.make_top_layer(this.previewActor);
 
         preview.x = preview.target_x + 200;
-        preview.y =  preview.target_y + 100;
+        preview.y = preview.target_y + 100;
         preview.width = preview.target_width;
         preview.height = preview.target_height;
 
-        Tweener.addTween(preview, {
+        this._manager.platform.tween(preview, {
             opacity: 255,
             x: preview.target_x,
             y: preview.target_y,
@@ -223,8 +215,7 @@ class TimelineSwitcher extends BaseSwitcher
         });
     }
 
-    _onFadeForwardComplete(preview, distance, animation_time)
-    {
+    _onFadeForwardComplete(preview, distance, animation_time) {
         preview.__looping = false;
         preview.make_bottom_layer(this.previewActor);
 
@@ -233,7 +224,7 @@ class TimelineSwitcher extends BaseSwitcher
         preview.width = Math.max(preview.target_width * ((20 - 2 * distance) / 20), 0);
         preview.height = Math.max(preview.target_height * ((20 - 2 * distance) / 20), 0);
 
-        Tweener.addTween(preview, {
+        this._manager.platform.tween(preview, {
             opacity: 255,
             time: animation_time / 2,
             transition: TRANSITION_TYPE,
@@ -243,10 +234,9 @@ class TimelineSwitcher extends BaseSwitcher
         });
     }
 
-    _onFinishMove(preview)
-    {
+    _onFinishMove(preview) {
         if (preview.__finalTween) {
-            Tweener.addTween(preview, preview.__finalTween);
+            this._manager.platform.tween(preview, preview.__finalTween);
             preview.__finalTween = null;
         }
     }


### PR DESCRIPTION
Tweener module was removed in 3.37 in favor of `Actor.ease` and `Actor.remove_all_transitions` which are injected into the prototype by ui.environment. This PR adds two functions into platforms (`tween` and `removeTweens`).

This is, again, quite untested as I'm not on my main computer right now and I don't have Shell 3.37 installed here. I didn't notice any regressions on 3.36, but I assume animations are broken under 3.37. Some properties were renamed and those'll need to be mapped.

Attempts to fix #131 .