### PR TITLE
fixed animation error after full rotate of all apps

### DIFF
--- a/CoverflowAltTab@dmo60.de/switcher.js
+++ b/CoverflowAltTab@dmo60.de/switcher.js
@@ -307,10 +307,6 @@ var Switcher = class Switcher {
             case Clutter.F4:
                 // Q -> Close window
                 this._manager.removeSelectedWindow(this._windows[this._currentIndex]);
-                this._checkDestroyedTimeoutId = Mainloop.timeout_add(
-                    CHECK_DESTROYED_TIMEOUT,
-                    () => this._checkDestroyed(this._windows[this._currentIndex])
-                );
                 return true;
 
             case Clutter.KEY_Right:


### PR DESCRIPTION
There were two bugs. one where the windows are not drawn exactly how they should after one full rotate of all apps.
and second is closing using f4 shows animation as if two apps are closed.