### PR TITLE
French translation update (new str. + consist. & corr.)

### DIFF
--- a/CONTRIBUTORS.markdown
+++ b/CONTRIBUTORS.markdown
@@ -38,4 +38,5 @@ CoverflowAltTab contributors (sorted randomly)
 * [Daniel Sheeler](https://github.com/dsheeler)
   * Keybindings for Gnome 3.36
   * Support for Gnome 42
- 
+* Simon Elst
+  * Maintaining French translation

--- a/CoverflowAltTab@dmo60.de/locale/fr/LC_MESSAGES/coverflow.po
+++ b/CoverflowAltTab@dmo60.de/locale/fr/LC_MESSAGES/coverflow.po
@@ -1,88 +1,107 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# narzb, 2016.
+# Simon Elst <kirmaha@duck.com>, 2022.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-05 00:06+0300\n"
-"PO-Revision-Date: 2016-01-05 00:06+0300\n"
+"POT-Creation-Date: 2022-05-14 22:52-0500\n"
+"PO-Revision-Date: 2022-11-19 10:41+0100\n"
 "Last-Translator: DAEM Q.\n"
+"Language-Team: \n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.5.4\n"
+"X-Generator: Poedit 3.1.1\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: prefs.js:28 prefs.js:48
+#: CoverflowAltTab@dmo60.de/prefs.js:45 CoverflowAltTab@dmo60.de/prefs.js:67
 msgid "Coverflow"
-msgstr ""
+msgstr "Coverflow"
 
-#: prefs.js:29 prefs.js:48
+#: CoverflowAltTab@dmo60.de/prefs.js:46 CoverflowAltTab@dmo60.de/prefs.js:67
 msgid "Timeline"
-msgstr ""
+msgstr "Ligne du temps"
 
-#: prefs.js:30 prefs.js:51
+#: CoverflowAltTab@dmo60.de/prefs.js:47 CoverflowAltTab@dmo60.de/prefs.js:100
 msgid "Bottom"
 msgstr "Bas"
 
-#: prefs.js:31 prefs.js:51
+#: CoverflowAltTab@dmo60.de/prefs.js:48 CoverflowAltTab@dmo60.de/prefs.js:100
 msgid "Top"
 msgstr "Haut"
 
-#: prefs.js:32 prefs.js:52
+#: CoverflowAltTab@dmo60.de/prefs.js:49 CoverflowAltTab@dmo60.de/prefs.js:101
 msgid "Classic"
 msgstr "Classique"
 
-#: prefs.js:33 prefs.js:52
+#: CoverflowAltTab@dmo60.de/prefs.js:50 CoverflowAltTab@dmo60.de/prefs.js:101
 msgid "Overlay"
-msgstr "Recouvre"
+msgstr "Superposé"
 
-#: prefs.js:42
-msgid ""
-"<b>Please restart Gnome-Shell to apply changes! (Hit Alt+F2, type 'r' and "
-"press Enter)\n"
-"</b>"
-msgstr ""
-"<b>Redémarrez Gnome-Shell pour appliquer les changements ! "
-"(Alt+F2, tapez 'r' puis tapez Entrer)\n"
-"</b>"
-
-#: prefs.js:46
+#: CoverflowAltTab@dmo60.de/prefs.js:65
 msgid "Hide panel during Coverflow"
 msgstr "Cacher la barre supérieure pendant le Coverflow"
 
-#: prefs.js:47
+#: CoverflowAltTab@dmo60.de/prefs.js:66
 msgid "Always show the switcher on the primary monitor"
 msgstr "Toujours afficher le Coverflow sur le moniteur principal"
 
-#: prefs.js:48
+#: CoverflowAltTab@dmo60.de/prefs.js:67
 msgid "Switcher style"
 msgstr "Style"
 
-#: prefs.js:49
+#: CoverflowAltTab@dmo60.de/prefs.js:97
+msgid "Easing for Coverflow animations"
+msgstr "Lissage des animations Coverflow"
+
+#: CoverflowAltTab@dmo60.de/prefs.js:98
 msgid "Animation speed (smaller means faster)"
-msgstr "Vitesse d'animation (plus bas = plus rapide)"
+msgstr "Vitesse d’animation (plus petit signifie plus rapide)"
 
-#: prefs.js:50
+#: CoverflowAltTab@dmo60.de/prefs.js:99
 msgid "Background dim-factor (smaller means darker)"
-msgstr "Arrière-plan dim-facteur (plus faible = plus sombre)"
+msgstr "Facteur dim d’arrière-plan (plus petit signifie plus sombre)"
 
-#: prefs.js:51
+#: CoverflowAltTab@dmo60.de/prefs.js:100
 msgid "Window title box position"
 msgstr "Position du cadre du titre de la fenêtre"
 
-#: prefs.js:52
+#: CoverflowAltTab@dmo60.de/prefs.js:101
 msgid "Application icon style"
-msgstr "Affichage de l'icone de l'application"
+msgstr "Affichage de l’icone de l’application"
 
-#: prefs.js:53
-msgid "Elastic animations"
-msgstr "Animations élastiques"
-
-#: prefs.js:54
+#: CoverflowAltTab@dmo60.de/prefs.js:102
 msgid "Vertical offset (positive value moves everything up, negative down)"
-msgstr "Décalage vertical (positif décale en haut, négatif en bas)"
+msgstr "Décalage vertical (positif vers le haut, négatif vers le bas)"
+
+#: CoverflowAltTab@dmo60.de/prefs.js:104
+msgid "Current workspace only"
+msgstr "Espace de travail actif uniquement"
+
+#: CoverflowAltTab@dmo60.de/prefs.js:106
+msgid "All workspaces"
+msgstr "Tous les espaces de travail"
+
+#: CoverflowAltTab@dmo60.de/prefs.js:108
+msgid "All workspaces, current first"
+msgstr "Tous les espaces de travail, actif d’abord"
+
+#: CoverflowAltTab@dmo60.de/prefs.js:110
+msgid "Show windows from current or all workspaces"
+msgstr "Afficher les fenêtres de l’espace de travail actif ou de tous"
+
+#: CoverflowAltTab@dmo60.de/prefs.js:111
+msgid "Only switch between windows on current monitor"
+msgstr "Changer de fenêtre uniquement sur le moniteur actif"
+
+#~ msgid ""
+#~ "<b>Please restart Gnome-Shell to apply changes! (Hit Alt+F2, type 'r' and press Enter)\n"
+#~ "</b>"
+#~ msgstr ""
+#~ "<b>Redémarrez Gnome-Shell pour appliquer les changements ! (Alt+F2, tapez 'r' puis tapez Entrer)\n"
+#~ "</b>"


### PR DESCRIPTION
New strings (last update : 7 years ago)
Better consistency regarding GNOME guidelines (use ’ of instead of ') and GNOME mutter translation.
Better internal consistency ("smaller" is "plus petit" + not using "=", "Overlay" is rather not used as a verb in French in this context, etc.)