### PR TITLE
Unbind switching panels to the extension (i.e. Ctrl+Alt+Tab shortcut)

### DIFF
--- a/CoverflowAltTab@dmo60.de/keybinder.js
+++ b/CoverflowAltTab@dmo60.de/keybinder.js
@@ -51,7 +51,6 @@ var Keybinder330Api = class Keybinder330Api extends AbstractKeybinder {
         platform.addSettingsChangedCallback(this._onSettingsChanged.bind(this));
 
         Main.wm.setCustomKeybindingHandler('switch-group', mode.NORMAL, startAppSwitcherBind);
-        Main.wm.setCustomKeybindingHandler('switch-panels', mode.NORMAL, startAppSwitcherBind);
         Main.wm.setCustomKeybindingHandler('switch-group-backward', mode.NORMAL, startAppSwitcherBind);
     }
 
@@ -61,7 +60,6 @@ var Keybinder330Api = class Keybinder330Api extends AbstractKeybinder {
         Main.wm.setCustomKeybindingHandler('switch-applications', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
         Main.wm.setCustomKeybindingHandler('switch-windows', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
         Main.wm.setCustomKeybindingHandler('switch-group', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
-        Main.wm.setCustomKeybindingHandler('switch-panels', mode.NORMAL, Main.wm._startA11ySwitcher.bind(Main.wm));
         Main.wm.setCustomKeybindingHandler('switch-applications-backward', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
         Main.wm.setCustomKeybindingHandler('switch-windows-backward', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
         Main.wm.setCustomKeybindingHandler('switch-group-backward', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));

--- a/CoverflowAltTab@dmo60.de/manager.js
+++ b/CoverflowAltTab@dmo60.de/manager.js
@@ -96,11 +96,6 @@ var Manager = class Manager {
         windowActors = null;
 
         switch (binding.get_name()) {
-            case 'switch-panels':
-                // Switch between windows of all workspaces
-                windows = windows.filter(matchSkipTaskbar);
-                break;
-
             case 'switch-group':
                 // Switch between windows of same application from all workspaces
                 let focused = display.focus_window ? display.focus_window : windows[0];

--- a/CoverflowAltTab@dmo60.de/switcher.js
+++ b/CoverflowAltTab@dmo60.de/switcher.js
@@ -349,7 +349,6 @@ var Switcher = class Switcher {
             case Meta.KeyBindingAction.SWITCH_APPLICATIONS:
             case Meta.KeyBindingAction.SWITCH_GROUP:
             case Meta.KeyBindingAction.SWITCH_WINDOWS:
-            case Meta.KeyBindingAction.SWITCH_PANELS:
                 if (this._checkSwitchTime()) {
                     // shift -> backwards
                     if (event_state & Clutter.ModifierType.SHIFT_MASK)
@@ -361,7 +360,6 @@ var Switcher = class Switcher {
             case Meta.KeyBindingAction.SWITCH_APPLICATIONS_BACKWARD:
             case Meta.KeyBindingAction.SWITCH_GROUP_BACKWARD:
             case Meta.KeyBindingAction.SWITCH_WINDOWS_BACKWARD:
-            case Meta.KeyBindingAction.SWITCH_PANELS_BACKWARD:
                 if (this._checkSwitchTime())
                     this._previous();
                 return true;


### PR DESCRIPTION
Closes #182.