### PR TITLE
Fix preferences label typos

### DIFF
--- a/locale/CoverflowAltTab@palatis.blogspot.com.pot
+++ b/locale/CoverflowAltTab@palatis.blogspot.com.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab@palatis.blogspot.com\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,11 +33,11 @@ msgstr ""
 msgid "Top"
 msgstr ""
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr ""
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr ""
 
@@ -100,7 +100,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -108,11 +108,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -161,122 +157,122 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
-msgid "Application Icon Style"
-msgstr ""
-
-#: src/prefs.js:182
 msgid "Overlay Icon Size"
 msgstr ""
 
-#: src/prefs.js:182
+#: src/prefs.js:181
 msgid "Set the overlay icon size in pixels."
 msgstr ""
 
-#: src/prefs.js:183
+#: src/prefs.js:182
 msgid "Overlay Icon Opacity"
 msgstr ""
 
-#: src/prefs.js:183
+#: src/prefs.js:182
 msgid "Set the overlay icon opacity."
 msgstr ""
 
-#: src/prefs.js:184
+#: src/prefs.js:185
+msgid "Application Icon Style"
+msgstr ""
+
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Background Dim-factor"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""

--- a/locale/CoverflowAltTab@palatis.blogspot.com.pot
+++ b/locale/CoverflowAltTab@palatis.blogspot.com.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab@palatis.blogspot.com\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -185,7 +185,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -246,7 +246,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2016-05-14 17:42+0200\n"
 "Last-Translator: Jiří Doubravský <jiri.doubravsky@gmail.com>\n"
 "Language-Team: CZECH <jiri.doubravsky@gmail.com>\n"
@@ -187,7 +187,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -249,7 +249,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2016-05-14 17:42+0200\n"
 "Last-Translator: Jiří Doubravský <jiri.doubravsky@gmail.com>\n"
 "Language-Team: CZECH <jiri.doubravsky@gmail.com>\n"
@@ -29,11 +29,11 @@ msgstr "Dole"
 msgid "Top"
 msgstr "Nahoře"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "Mimo okno"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "Uprostřed okna"
 
@@ -100,7 +100,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -108,11 +108,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -162,125 +158,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "Styl zobrazení ikon aplikací"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "Světlost pozadí (méně je tmavší)"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/de.po
+++ b/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2019-06-17 17:27+0200\n"
 "Last-Translator: Onno Giesmann <nutzer3105@gmail.com>\n"
 "Language-Team: German <jonatan_zeidler@gmx.de>\n"
@@ -196,7 +196,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -258,7 +258,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/de.po
+++ b/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2019-06-17 17:27+0200\n"
 "Last-Translator: Onno Giesmann <nutzer3105@gmail.com>\n"
 "Language-Team: German <jonatan_zeidler@gmx.de>\n"
@@ -34,11 +34,11 @@ msgstr "Unten"
 msgid "Top"
 msgstr "Oben"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "Klassisch"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "Überlagern"
 
@@ -107,7 +107,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -115,11 +115,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -171,125 +167,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "Stil des Anwendungssymbols"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "Hintergrundabblendfaktor (kleiner bedeutet dunkler)"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2022-11-19 10:41+0100\n"
 "Last-Translator: DAEM Q.\n"
 "Language-Team: \n"
@@ -196,7 +196,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -258,7 +258,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2022-11-19 10:41+0100\n"
 "Last-Translator: DAEM Q.\n"
 "Language-Team: \n"
@@ -35,11 +35,11 @@ msgstr "Bas"
 msgid "Top"
 msgstr "Haut"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "Classique"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "Superposé"
 
@@ -106,7 +106,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -114,11 +114,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -171,125 +167,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "Affichage de l’icone de l’application"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "Facteur dim d’arrière-plan (plus petit signifie plus sombre)"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/it.po
+++ b/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2016-05-14 17:40+0200\n"
 "Last-Translator: Paolo Inaudi <p91paul@gmail.com>\n"
 "Language-Team: Italian <p91paul@gmail.com>\n"
@@ -35,11 +35,11 @@ msgstr "Sotto"
 msgid "Top"
 msgstr "Sopra"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "Classico"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "In trasparenza"
 
@@ -108,7 +108,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -116,11 +116,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -173,125 +169,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "Stile delle icone delle applicazioni"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "Oscuramento dello sfondo (più piccolo significa più scuro)"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/it.po
+++ b/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2016-05-14 17:40+0200\n"
 "Last-Translator: Paolo Inaudi <p91paul@gmail.com>\n"
 "Language-Team: Italian <p91paul@gmail.com>\n"
@@ -198,7 +198,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -260,7 +260,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: coverflow\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2021-09-22 20:45+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -33,11 +33,11 @@ msgstr "下部"
 msgid "Top"
 msgstr "上部"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "クラシック"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "オーバーレイ"
 
@@ -104,7 +104,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -112,11 +112,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -169,125 +165,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "アプリアイコンのスタイル"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "バックグラウンドの暗さ（小さくするほど暗くなります）"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: coverflow\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2021-09-22 20:45+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -194,7 +194,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -256,7 +256,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2021-07-11 19:01+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <kde-i18n-doc@kde.org>\n"
@@ -33,11 +33,11 @@ msgstr "Onderaan"
 msgid "Top"
 msgstr "Bovenaan"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "Klassiek"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "Bovenop"
 
@@ -106,7 +106,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -114,11 +114,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -171,125 +167,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "Pictogramstijl"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "Dimfactor van achtergrond (lager = donkerder)"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2021-07-11 19:01+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <kde-i18n-doc@kde.org>\n"
@@ -196,7 +196,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -258,7 +258,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2016-05-14 17:43+0200\n"
 "Last-Translator: Fábio Nogueira <deb-user-ba@ubuntu.com>\n"
 "Language-Team: \n"
@@ -34,11 +34,11 @@ msgstr "Base"
 msgid "Top"
 msgstr "Topo"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "Clássico"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "Sobreposição"
 
@@ -106,7 +106,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -114,11 +114,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -170,125 +166,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "Estilo do ícone do aplicativo"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "Ofuscador de plano de fundo (menor significa escuro)"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2016-05-14 17:43+0200\n"
 "Last-Translator: Fábio Nogueira <deb-user-ba@ubuntu.com>\n"
 "Language-Team: \n"
@@ -195,7 +195,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -257,7 +257,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2020-05-07 20:21+0300\n"
 "Last-Translator: Roman Kaverin <roman.kaverin@gmail.com>\n"
 "Language-Team: \n"
@@ -195,7 +195,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -257,7 +257,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2020-05-07 20:21+0300\n"
 "Last-Translator: Roman Kaverin <roman.kaverin@gmail.com>\n"
 "Language-Team: \n"
@@ -35,11 +35,11 @@ msgstr "Снизу"
 msgid "Top"
 msgstr "Сверху"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "Классическое"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "Поверх окна"
 
@@ -106,7 +106,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -114,11 +114,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -170,125 +166,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "Расположение иконки приложения"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "Затемнение фона (меньше значит темнее)"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2021-04-12 16:08+0200\n"
 "Last-Translator: Morgan Antonsson <morgan.antonsson@gmail.com>\n"
 "Language-Team: \n"
@@ -195,7 +195,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -257,7 +257,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/sv.po
+++ b/locale/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2021-04-12 16:08+0200\n"
 "Last-Translator: Morgan Antonsson <morgan.antonsson@gmail.com>\n"
 "Language-Team: \n"
@@ -33,11 +33,11 @@ msgstr "Under"
 msgid "Top"
 msgstr "Över"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "Klassisk"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "Överlagrad"
 
@@ -105,7 +105,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -113,11 +113,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -170,125 +166,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "Applikationsikonstil"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "Bakgrundens dämpningsfaktor (mindre betyder mörkare)"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2020-10-29 15:00+0300\n"
 "Last-Translator: Muha Aliss <muhaaliss@pm.me>\n"
 "Language-Team: Turkish <muhaaliss@pm.me>\n"
@@ -35,11 +35,11 @@ msgstr "Alt"
 msgid "Top"
 msgstr "Üst"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "Klasik"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "Kaplı"
 
@@ -108,7 +108,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -116,11 +116,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -172,125 +168,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "Uygulama simge stili"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "Arka plan karartma (daha az, daha koyu demektir)"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CoverflowAltTab Gnome-Shell extension\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2020-10-29 15:00+0300\n"
 "Last-Translator: Muha Aliss <muhaaliss@pm.me>\n"
 "Language-Team: Turkish <muhaaliss@pm.me>\n"
@@ -197,7 +197,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -259,7 +259,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2018-01-08 18:44-0800\n"
 "Last-Translator: gesangtome <gesangtome@foxmail.com>\n"
 "Language-Team: gesangtome <gesangtome@foxmail.com>\n"
@@ -195,7 +195,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -257,7 +257,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2018-01-08 18:44-0800\n"
 "Last-Translator: gesangtome <gesangtome@foxmail.com>\n"
 "Language-Team: gesangtome <gesangtome@foxmail.com>\n"
@@ -35,11 +35,11 @@ msgstr "底部"
 msgid "Top"
 msgstr "顶部"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "经典"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "叠加"
 
@@ -106,7 +106,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -114,11 +114,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -170,125 +166,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "应用图标风格"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "背景暗淡因数（越小越暗）"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-06 06:48+0330\n"
+"POT-Creation-Date: 2023-01-29 17:05+0000\n"
 "PO-Revision-Date: 2020-05-24 15:50+0800\n"
 "Last-Translator: Yi-Jyun Pan <pan93412@gmail.com>\n"
 "Language-Team: \n"
@@ -34,11 +34,11 @@ msgstr "底部"
 msgid "Top"
 msgstr "頂部"
 
-#: src/prefs.js:119 src/prefs.js:181
+#: src/prefs.js:119 src/prefs.js:184
 msgid "Classic"
 msgstr "傳統式"
 
-#: src/prefs.js:120 src/prefs.js:181
+#: src/prefs.js:120 src/prefs.js:184
 msgid "Overlay"
 msgstr "覆蓋式"
 
@@ -105,7 +105,7 @@ msgid "Hide Panel"
 msgstr ""
 
 #: src/prefs.js:155
-msgid "Hide panel when switching widnows."
+msgid "Hide panel when switching windows."
 msgstr ""
 
 #: src/prefs.js:158
@@ -113,11 +113,7 @@ msgid "Animation"
 msgstr ""
 
 #: src/prefs.js:162
-msgid "Duration"
-msgstr ""
-
-#: src/prefs.js:162
-msgid "In seconds."
+msgid "Duration [s]"
 msgstr ""
 
 #: src/prefs.js:163
@@ -169,125 +165,125 @@ msgid "Icon"
 msgstr ""
 
 #: src/prefs.js:181
+msgid "Overlay Icon Size"
+msgstr ""
+
+#: src/prefs.js:181
+msgid "Set the overlay icon size in pixels."
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Overlay Icon Opacity"
+msgstr ""
+
+#: src/prefs.js:182
+msgid "Set the overlay icon opacity."
+msgstr ""
+
+#: src/prefs.js:185
 #, fuzzy
 msgid "Application Icon Style"
 msgstr "應用程式圖示樣式"
 
-#: src/prefs.js:182
-msgid "Overlay Icon Size"
-msgstr ""
-
-#: src/prefs.js:182
-msgid "Set the overlay icon size in pixels."
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Overlay Icon Opacity"
-msgstr ""
-
-#: src/prefs.js:183
-msgid "Set the overlay icon opacity."
-msgstr ""
-
-#: src/prefs.js:184
+#: src/prefs.js:188
 msgid "Icon Shadow"
 msgstr ""
 
-#: src/prefs.js:187
+#: src/prefs.js:191
 msgid "Window Size"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Window Preview Size to Monintor Size Ratio"
 msgstr ""
 
-#: src/prefs.js:189
+#: src/prefs.js:193
 msgid "Maximum ratio of window preview size to monitor size."
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Off-center Size Factor"
 msgstr ""
 
-#: src/prefs.js:190
+#: src/prefs.js:194
 msgid "Factor by which to successively shrink previews off to the side"
 msgstr ""
 
-#: src/prefs.js:193
+#: src/prefs.js:197
 msgid "Background"
 msgstr ""
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 #, fuzzy
 msgid "Background Dim-factor"
 msgstr "背景暗度因數（越小越暗）"
 
-#: src/prefs.js:195
+#: src/prefs.js:199
 msgid "Smaller means darker."
 msgstr ""
 
-#: src/prefs.js:198
+#: src/prefs.js:202
 msgid "Keybindings"
 msgstr ""
 
-#: src/prefs.js:200
+#: src/prefs.js:204
 msgid "Bind to 'switch-windows'"
 msgstr ""
 
-#: src/prefs.js:201
+#: src/prefs.js:205
 msgid "Bind to 'switch-applications'"
 msgstr ""
 
-#: src/prefs.js:214 src/prefs.js:220
+#: src/prefs.js:218 src/prefs.js:224
 msgid "Perspective Correction"
 msgstr ""
 
-#: src/prefs.js:217
+#: src/prefs.js:221
 msgid "None"
 msgstr ""
 
-#: src/prefs.js:218
+#: src/prefs.js:222
 msgid "Move Camera"
 msgstr ""
 
-#: src/prefs.js:219
+#: src/prefs.js:223
 msgid "Adjust Angles"
 msgstr ""
 
-#: src/prefs.js:223 src/prefs.js:225
+#: src/prefs.js:227 src/prefs.js:229
 msgid "Highlight Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:225
+#: src/prefs.js:229
 msgid ""
 "Draw embelishment on window under the mouse to know the effects of clicking."
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise Window Under Mouse"
 msgstr ""
 
-#: src/prefs.js:226
+#: src/prefs.js:230
 msgid "Raise the window under the mouse above all others."
 msgstr ""
 
-#: src/prefs.js:229
+#: src/prefs.js:233
 msgid "Tweaks"
 msgstr ""
 
-#: src/prefs.js:236
+#: src/prefs.js:240
 msgid "Appearance"
 msgstr ""
 
-#: src/prefs.js:241
+#: src/prefs.js:245
 msgid "Contribute"
 msgstr ""
 
-#: src/prefs.js:277
+#: src/prefs.js:281
 msgid "Code (create pull requests, report issues, etc.)"
 msgstr ""
 
-#: src/prefs.js:284
+#: src/prefs.js:288
 msgid "Support me with a Donation"
 msgstr ""
 

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-01-29 17:05+0000\n"
+"POT-Creation-Date: 2023-01-29 17:11+0000\n"
 "PO-Revision-Date: 2020-05-24 15:50+0800\n"
 "Last-Translator: Yi-Jyun Pan <pan93412@gmail.com>\n"
 "Language-Team: \n"
@@ -194,7 +194,7 @@ msgid "Window Size"
 msgstr ""
 
 #: src/prefs.js:193
-msgid "Window Preview Size to Monintor Size Ratio"
+msgid "Window Preview Size to Monitor Size Ratio"
 msgstr ""
 
 #: src/prefs.js:193
@@ -256,7 +256,7 @@ msgstr ""
 
 #: src/prefs.js:229
 msgid ""
-"Draw embelishment on window under the mouse to know the effects of clicking."
+"Draw embellishment on window under the mouse to show the effects of clicking."
 msgstr ""
 
 #: src/prefs.js:230

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -152,7 +152,7 @@ function fillPreferencesWindow(window) {
 	let behavior_pref_group = new Adw.PreferencesGroup({
 		title: _("Behavior"),
 	});
-	behavior_pref_group.add(buildSwitcherAdw(settings, "hide-panel", _("Hide Panel"), _("Hide panel when switching widnows.")));
+	behavior_pref_group.add(buildSwitcherAdw(settings, "hide-panel", _("Hide Panel"), _("Hide panel when switching windows.")));
 
 	let animation_pref_group = new Adw.PreferencesGroup({
 		title: _('Animation'),

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -190,7 +190,7 @@ function fillPreferencesWindow(window) {
 	let window_size_pref_group = new Adw.PreferencesGroup({
 		title: _("Window Size")
 	});
-	window_size_pref_group.add(buildRangeAdw(settings, "preview-to-monitor-ratio", [0, 1, 0.001, [0.250, 0.500, 0.750]], _("Window Preview Size to Monintor Size Ratio"), _("Maximum ratio of window preview size to monitor size."), true));
+	window_size_pref_group.add(buildRangeAdw(settings, "preview-to-monitor-ratio", [0, 1, 0.001, [0.250, 0.500, 0.750]], _("Window Preview Size to Monitor Size Ratio"), _("Maximum ratio of window preview size to monitor size."), true));
 	window_size_pref_group.add(buildRangeAdw(settings, "preview-scaling-factor", [0, 1, 0.001, [0.250, 0.500, 0.800]], _("Off-center Size Factor"), _("Factor by which to successively shrink previews off to the side"), true));
 
 	let background_pref_group = new Adw.PreferencesGroup({
@@ -226,7 +226,7 @@ function fillPreferencesWindow(window) {
 	let highlight_mouse_over_pref_group = new Adw.PreferencesGroup({
 		title: _("Highlight Window Under Mouse"),
 	});
-	highlight_mouse_over_pref_group.add(buildSwitcherAdw(settings, "highlight-mouse-over", _("Highlight Window Under Mouse"), _("Draw embelishment on window under the mouse to know the effects of clicking.")));
+	highlight_mouse_over_pref_group.add(buildSwitcherAdw(settings, "highlight-mouse-over", _("Highlight Window Under Mouse"), _("Draw embellishment on window under the mouse to show the effects of clicking.")));
 	highlight_mouse_over_pref_group.add(buildSwitcherAdw(settings, "raise-mouse-over", _("Raise Window Under Mouse"), _("Raise the window under the mouse above all others.")));
 
 	let tweaks_page = new Adw.PreferencesPage({


### PR DESCRIPTION
Updated a couple of small spelling mistakes / typos in words in the preferences dialog.
Regenerated translation files.
