### PR TITLE
Ignore built files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/build/
-/locale/*.mo
+*.mo
+schemas/gschemas.compiled
+*.zip


### PR DESCRIPTION
Hello, it would be better to ignore gschemas compiled files. Also I think we can make all mo and zip files ignored.