### PR TITLE
Add support for GNOME 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,7 @@
     "gettext-domain": "CoverflowAltTab@palatis.blogspot.com",
     "name": "Coverflow Alt-Tab",
     "settings-schema": "org.gnome.shell.extensions.coverflowalttab",
-    "shell-version": ["49"],
+    "shell-version": ["49", "50"],
     "uuid": "CoverflowAltTab@palatis.blogspot.com",
     "description": "Replacement of Alt-Tab, iterates through windows in a cover-flow manner.",
     "url": "https://github.com/dsheeler/CoverflowAltTab"


### PR DESCRIPTION
Preparing for GNOME 50.0 release on March 18.

Tested on GNOME 50.beta and 50.rc. Current version works without issues for me.