### PR TITLE
Sync SwipeTracker to GNOME 50

### DIFF
--- a/src/swipeTracker.js
+++ b/src/swipeTracker.js
@@ -103,7 +103,7 @@ const TouchpadSwipeGesture = GObject.registerClass({
         'end':    {param_types: [GObject.TYPE_UINT, GObject.TYPE_DOUBLE]},
     },
 }, class TouchpadSwipeGesture extends GObject.Object {
-    constructor(/* allowedModes */) {
+    constructor(actor, /* allowedModes */) {
         super();
         /* this._allowedModes = allowedModes; */
         this._state = TouchpadState.NONE;
@@ -113,8 +113,8 @@ const TouchpadSwipeGesture = GObject.registerClass({
             schema_id: 'org.gnome.desktop.peripherals.touchpad',
         });
 
-        global.stage.connectObject(
-            'captured-event::touchpad', this._handleEvent.bind(this), this);
+        actor.connectObject(
+            'event::touchpad', this._handleEvent.bind(this), this);
     }
 
     // eslint-disable-next-line complexity
@@ -137,7 +137,7 @@ const TouchpadSwipeGesture = GObject.registerClass({
         if (this._state === TouchpadState.IGNORED)
             return Clutter.EVENT_PROPAGATE;
 
-        let time = event.get_time();
+        const time = event.get_time();
 
         const [x, y] = event.get_coords();
         const [dx, dy] = event.get_gesture_motion_delta_unaccelerated();
@@ -284,8 +284,8 @@ const ScrollGesture = GObject.registerClass({
         const vertical = this.orientation === Clutter.Orientation.VERTICAL;
         const distance = vertical ? TOUCHPAD_BASE_HEIGHT : TOUCHPAD_BASE_WIDTH;
 
-        let time = event.get_time();
-        let [dx, dy] = event.get_scroll_delta();
+        const time = event.get_time();
+        const [dx, dy] = event.get_scroll_delta();
         if (dx === 0 && dy === 0) {
             this.emit('end', time, distance);
             this._began = false;
@@ -293,7 +293,7 @@ const ScrollGesture = GObject.registerClass({
         }
 
         if (!this._began) {
-            let [x, y] = event.get_coords();
+            const [x, y] = event.get_coords();
             this.emit('begin', time, x, y);
             this._began = true;
         }
@@ -514,7 +514,7 @@ export const SwipeTracker = GObject.registerClass({
             null);
         actor.add_action_full(params.name, params.phase, this._panGesture);
 
-        this._touchpadGesture = new TouchpadSwipeGesture(/* allowedModes */);
+        this._touchpadGesture = new TouchpadSwipeGesture(actor, /* allowedModes */);
         this._touchpadGesture.connect('begin', this._beginTouchpadGesture.bind(this));
         this._touchpadGesture.connect('update', this._updateTouchpadGesture.bind(this));
         this._touchpadGesture.connect('end', this._endTouchpadGesture.bind(this));
@@ -611,7 +611,7 @@ export const SwipeTracker = GObject.registerClass({
             return;
 
         const rect = new Mtk.Rectangle({x, y, width: 1, height: 1});
-        let monitor = global.display.get_monitor_index_for_rect(rect);
+        const monitor = global.display.get_monitor_index_for_rect(rect);
 
         this.emit('begin', monitor);
     }
@@ -639,8 +639,14 @@ export const SwipeTracker = GObject.registerClass({
     }
 
     _findPreviousPoint(pos) {
-        const reversedIndex = this._snapPoints.slice().reverse().findIndex(p => p <= pos);
-        return this._snapPoints.length - 1 - reversedIndex;
+        const index =
+            this._snapPoints.findLastIndex(p => p <= pos);
+        if (index !== -1)
+            return index;
+
+        console.trace(`Invalid position ${pos}`);
+        // also out-of-bounds, but somehow callers fail less hard than with -1
+        return this._snapPoints.length;
     }
 
     _findPointForProjection(pos, velocity) {
@@ -679,10 +685,6 @@ export const SwipeTracker = GObject.registerClass({
         if (this._state !== State.SCROLLING)
             return;
 
-        if (this.orientation === Clutter.Orientation.HORIZONTAL &&
-            Clutter.get_default_text_direction() === Clutter.TextDirection.RTL)
-            delta = -delta;
-
         if (this._inverted) {
             delta = -delta;
         }
@@ -702,8 +704,8 @@ export const SwipeTracker = GObject.registerClass({
     _updatePanGesture(panGesture) {
         const deltaVec = panGesture.get_delta();
         let delta = this.orientation === Clutter.Orientation.HORIZONTAL
-            ? -deltaVec.get_x()
-            : -deltaVec.get_y();
+            ? this._getGestureDirFactor() * deltaVec.get_x()
+            : this._getGestureDirFactor() * deltaVec.get_y();
 
          if (!this._settings.natural_scrolling) {
             delta = -delta;
@@ -717,6 +719,10 @@ export const SwipeTracker = GObject.registerClass({
             this._interrupt();
             return;
         }
+
+        if (this.orientation === Clutter.Orientation.HORIZONTAL &&
+            Clutter.get_default_text_direction() === Clutter.TextDirection.RTL)
+            delta = -delta;
 
         this._history.append(time, delta);
         this._updateGesture(delta, distance);
@@ -789,8 +795,8 @@ export const SwipeTracker = GObject.registerClass({
     _endPanGesture(panGesture) {
         const velocity = panGesture.get_velocity();
         let v = this.orientation === Clutter.Orientation.HORIZONTAL
-            ? -velocity.get_x()
-            : -velocity.get_y();
+            ? this._getGestureDirFactor() * velocity.get_x()
+            : this._getGestureDirFactor() * velocity.get_y();
 
         if (!this._settings.natural_scrolling) {
             v = -v;
@@ -823,6 +829,14 @@ export const SwipeTracker = GObject.registerClass({
 
         this._cancelled = true;
         this._endGesture(0, this._distance, false);
+    }
+
+    _getGestureDirFactor() {
+        if (this.orientation === Clutter.Orientation.HORIZONTAL &&
+            Clutter.get_default_text_direction() === Clutter.TextDirection.RTL)
+            return 1;
+
+        return -1;
     }
 
     /**


### PR DESCRIPTION
Not sure if you're interested in doing this right now, but these would be changes in `swipeTracker.js` introduced between GNOME 49.rc and GNOME 50.rc. They should work with GNOME 49 too, however the orientation changes could be a bit risky for both versions. For comparison, check commits for `swipeTracker.js` on:

- [GNOME 49.rc](https://gitlab.gnome.org/GNOME/gnome-shell/-/commits/49.rc/js/ui/swipeTracker.js) (last sync)
- [GNOME 49.4](https://gitlab.gnome.org/GNOME/gnome-shell/-/commits/49.4/js/ui/swipeTracker.js) (previous release)
- [GNOME 50.0](https://gitlab.gnome.org/GNOME/gnome-shell/-/commits/50.0/js/ui/swipeTracker.js) (current stable)

I'm opening as draft right now, but, if there is interest, I could do a proper test and open it to review if it works.