### PR TITLE
Adapt for GNOME 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,7 @@
     "settings-schema": "org.gnome.shell.extensions.coverflowalttab",
     "shell-version": ["50"],
     "uuid": "CoverflowAltTab@palatis.blogspot.com",
+    "version": 84,
     "description": "Replacement of Alt-Tab, iterates through windows in a cover-flow manner.",
     "url": "https://github.com/dsheeler/CoverflowAltTab"
 }

--- a/src/keybinder.js
+++ b/src/keybinder.js
@@ -39,6 +39,7 @@ export const Keybinder330Api = class Keybinder330Api extends AbstractKeybinder {
 
         this._settings = settings;
         this._startAppSwitcherBind = null;
+        this._defaultSwitcherBind = Main.wm._startSwitcher.bind(Main.wm);
         this._keybindingActions = new Map();
     }
 
@@ -99,12 +100,12 @@ export const Keybinder330Api = class Keybinder330Api extends AbstractKeybinder {
 
     disable() {
         let mode = Shell.ActionMode ? Shell.ActionMode : Shell.KeyBindingMode;
-        Main.wm.setCustomKeybindingHandler('switch-applications', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
-        Main.wm.setCustomKeybindingHandler('switch-windows', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
-        Main.wm.setCustomKeybindingHandler('switch-group', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
-        Main.wm.setCustomKeybindingHandler('switch-applications-backward', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
-        Main.wm.setCustomKeybindingHandler('switch-windows-backward', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
-        Main.wm.setCustomKeybindingHandler('switch-group-backward', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
+        Main.wm.setCustomKeybindingHandler('switch-applications', mode.NORMAL, this._defaultSwitcherBind);
+        Main.wm.setCustomKeybindingHandler('switch-windows', mode.NORMAL, this._defaultSwitcherBind);
+        Main.wm.setCustomKeybindingHandler('switch-group', mode.NORMAL, this._defaultSwitcherBind);
+        Main.wm.setCustomKeybindingHandler('switch-applications-backward', mode.NORMAL, this._defaultSwitcherBind);
+        Main.wm.setCustomKeybindingHandler('switch-windows-backward', mode.NORMAL, this._defaultSwitcherBind);
+        Main.wm.setCustomKeybindingHandler('switch-group-backward', mode.NORMAL, this._defaultSwitcherBind);
 
         this.removeKeybinding("coverflow-switch-windows");
         this.removeKeybinding("coverflow-switch-windows-on-all-workspaces");
@@ -120,8 +121,8 @@ export const Keybinder330Api = class Keybinder330Api extends AbstractKeybinder {
                 Main.wm.setCustomKeybindingHandler('switch-applications', mode.NORMAL, this._startAppSwitcherBind);
                 Main.wm.setCustomKeybindingHandler('switch-applications-backward', mode.NORMAL, this._startAppSwitcherBind);
             } else {
-                Main.wm.setCustomKeybindingHandler('switch-applications', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
-                Main.wm.setCustomKeybindingHandler('switch-applications-backward', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
+                Main.wm.setCustomKeybindingHandler('switch-applications', mode.NORMAL, this._defaultSwitcherBind);
+                Main.wm.setCustomKeybindingHandler('switch-applications-backward', mode.NORMAL, this._defaultSwitcherBind);
             }
         }
         if (key === null || key === 'bind-to-switch-windows') {
@@ -129,8 +130,8 @@ export const Keybinder330Api = class Keybinder330Api extends AbstractKeybinder {
                 Main.wm.setCustomKeybindingHandler('switch-windows', mode.NORMAL, this._startAppSwitcherBind);
                 Main.wm.setCustomKeybindingHandler('switch-windows-backward', mode.NORMAL, this._startAppSwitcherBind);
             } else {
-                Main.wm.setCustomKeybindingHandler('switch-windows', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
-                Main.wm.setCustomKeybindingHandler('switch-windows-backward', mode.NORMAL, Main.wm._startSwitcher.bind(Main.wm));
+                Main.wm.setCustomKeybindingHandler('switch-windows', mode.NORMAL, this._defaultSwitcherBind);
+                Main.wm.setCustomKeybindingHandler('switch-windows-backward', mode.NORMAL, this._defaultSwitcherBind);
             }
         }
     }

--- a/src/manager.js
+++ b/src/manager.js
@@ -41,7 +41,7 @@ function matchWmClass(win) {
 }
 
 function matchOnAllWorkspaces(win) {
-    return win.on_all_workspaces && !win.is_skip_taskbar();
+    return !win.is_skip_taskbar();
 }
 
 function matchWorkspace(win) {
@@ -61,15 +61,8 @@ export const Manager = class Manager {
         this.switcher = null;
         this.exportedObject = null;
 
-        if (global.workspace_manager && global.workspace_manager.get_active_workspace)
-            this.workspace_manager = global.workspace_manager;
-        else
-            this.workspace_manager = global.screen;
-
-        if (global.display && global.display.get_n_monitors)
-            this.display = global.display;
-        else
-            this.display = global.screen;
+        this.workspace_manager = global.workspace_manager;
+        this.display = global.display;
     }
 
     enable() {
@@ -274,6 +267,5 @@ export const Manager = class Manager {
         }
     }
 }
-
 
 

--- a/src/manager.js
+++ b/src/manager.js
@@ -163,6 +163,9 @@ export const Manager = class Manager {
             }
         }
 
+        if (windows.length === 0)
+            return;
+
         let currentOnly = this.platform.getSettings().current_workspace_only;
         let focused = display.focus_window ? display.focus_window : windows[0];
 
@@ -267,5 +270,4 @@ export const Manager = class Manager {
         }
     }
 }
-
 

--- a/src/swipeTracker.js
+++ b/src/swipeTracker.js
@@ -485,7 +485,7 @@ export const SwipeTracker = GObject.registerClass({
         this._settings = settings;
         /* this._allowedModes = allowedModes; */
         this._enabled = true;
-        this._distance = global.screen_height;
+        this._distance = global.stage.height;
         this._history = new EventHistory();
         this._reset();
         this._inverted = params.inverted;

--- a/src/swipeTracker.js
+++ b/src/swipeTracker.js
@@ -112,6 +112,7 @@ const TouchpadSwipeGesture = GObject.registerClass({
         this._touchpadSettings = new Gio.Settings({
             schema_id: 'org.gnome.desktop.peripherals.touchpad',
         });
+        this._actor = actor;
 
         actor.connectObject(
             'event::touchpad', this._handleEvent.bind(this), this);
@@ -205,7 +206,8 @@ const TouchpadSwipeGesture = GObject.registerClass({
     }
 
     destroy() {
-        global.stage.disconnectObject(this);
+        this._actor.disconnectObject(this);
+        this._actor = null;
     }
 });
 
@@ -235,8 +237,9 @@ const ScrollGesture = GObject.registerClass({
         /* this._allowedModes = allowedModes; */
         this._began = false;
         this._enabled = true;
+        this._actor = actor;
 
-        actor.connect('scroll-event', this._handleEvent.bind(this));
+        this._scrollEventId = actor.connect('scroll-event', this._handleEvent.bind(this));
     }
 
     get enabled() {
@@ -304,6 +307,14 @@ const ScrollGesture = GObject.registerClass({
 
         return Clutter.EVENT_STOP;
     }
+
+    destroy() {
+        if (this._scrollEventId) {
+            this._actor.disconnect(this._scrollEventId);
+            this._scrollEventId = 0;
+        }
+        this._actor = null;
+    }
 });
 
 const MouseScroll = GObject.registerClass({
@@ -328,10 +339,11 @@ const MouseScroll = GObject.registerClass({
             schema_id: 'org.gnome.desktop.peripherals.mouse',
         });
         this._natural_scrolling =    this._mouseSettings.get_boolean('natural-scroll');
-        this._mouseSettings.connect('changed::natural-scroll', (settings, key) => {
+        this._mouseSettingsChangedId = this._mouseSettings.connect('changed::natural-scroll', (settings, key) => {
             this._natural_scrolling = settings.get_boolean(key);
         });
-        actor.connect('scroll-event', this._handleEvent.bind(this));
+        this._actor = actor;
+        this._scrollEventId = actor.connect('scroll-event', this._handleEvent.bind(this));
     }
 
     get enabled() {
@@ -407,6 +419,15 @@ const MouseScroll = GObject.registerClass({
             GLib.Source.remove(this._gestureTimeoutId);
             this._gestureTimeoutId = 0;
         }
+        if (this._scrollEventId) {
+            this._actor.disconnect(this._scrollEventId);
+            this._scrollEventId = 0;
+        }
+        if (this._mouseSettingsChangedId) {
+            this._mouseSettings.disconnect(this._mouseSettingsChangedId);
+            this._mouseSettingsChangedId = 0;
+        }
+        this._actor = null;
     }
 });
 
@@ -871,6 +892,11 @@ export const SwipeTracker = GObject.registerClass({
         if (this._panGesture) {
             this._panGesture.actor?.remove_action(this._panGesture);
             delete this._panGesture;
+        }
+
+        if (this._scrollGesture) {
+            this._scrollGesture.destroy();
+            delete this._scrollGesture;
         }
 
         if (this._mouseScroll) {

--- a/src/switcher.js
+++ b/src/switcher.js
@@ -1156,7 +1156,7 @@ export class Switcher {
         if (this._parent === null) this._manager.platform.removeBackground();
 
         this._disablePerspectiveCorrection();
-        Main.uiGroup.remove_child(this.actor);
+        this.actor.destroy();
         this._destroyed = true;
         this._logger.decreaseIndent();
         this._logger.log("Destroying Switcher DONE");


### PR DESCRIPTION
This updates the extension for GNOME 50 compatibility.
Changes:
- Remove legacy `global.screen` fallbacks and use `global.workspace_manager` / `global.display`.
- Replace `global.screen_height` with `global.stage.height`.
- Fix the all-workspaces switcher filter so it includes eligible windows.
- Preserve the default GNOME Shell switcher handler and restore it when the extension is disabled.
Tested:
- `make schema` passes.
- `git diff --check` passes.
Note:
- `make build` could not be completed locally because `msgfmt` was missing from the system.