### PR TITLE
Fix windows from other workspaces ghosting onto the current workspace

### DIFF
--- a/src/switcher.js
+++ b/src/switcher.js
@@ -209,9 +209,15 @@ export class Switcher {
         }
 
         // hide windows and showcd  Coverflow actors
+        // Only hide windows on the current workspace. Hiding (and later
+        // re-showing) windows from other workspaces makes them briefly render
+        // on the current workspace as non-interactive ghosts on GNOME 48+.
         if (this._parent === null) {
+            let currentWorkspace = this._manager.workspace_manager.get_active_workspace();
             for (let child of global.window_group.get_children()) {
-                if (child !== global.window_group.get_first_child()) {
+                if (child !== global.window_group.get_first_child()
+                    && typeof child.get_meta_window === "function"
+                    && child.get_meta_window().get_workspace() === currentWorkspace) {
                     child.hide();
                 }
             }
@@ -1161,9 +1167,14 @@ export class Switcher {
 
         if (this._parent === null) this._manager.platform.removeBackground();
         if (this._parent === null) {
+            let currentWorkspace = this._manager.workspace_manager.get_active_workspace();
             for (let child of global.window_group.get_children()) {
                 if (typeof child.get_meta_window === "function") {
-                    if (!child.get_meta_window().minimized) {
+                    let metaWin = child.get_meta_window();
+                    // Only re-show windows that belong to the current workspace.
+                    // Re-showing windows from other workspaces is what left them
+                    // ghosting on the current workspace after a switch.
+                    if (!metaWin.minimized && metaWin.get_workspace() === currentWorkspace) {
                         child.show();
                     }
                 }


### PR DESCRIPTION
## What's happening

On GNOME Shell 50 (Wayland) I kept hitting a glitch: every time I trigger the switcher, the windows that live on my *other* workspaces suddenly appear on top of my current workspace. They're just ghosts — I can't click or focus them, they only render. Switching to another workspace and back clears them, until the next Alt+Tab brings them back.

## Cause

In `src/switcher.js` the switcher hides the real windows on open and re-shows them on close, but both loops walk **all** of `global.window_group` without checking the workspace:

- On open it does `child.hide()` on every window (all workspaces).
- On close it does `child.show()` on every non-minimized window (all workspaces).

That `child.show()` on close is the problem — it force-shows windows that belong to other workspaces, overriding mutter's normal per-workspace culling. On GNOME 48+ that stays visible until the next workspace recompute, which is exactly the ghosting + "fine until I Alt+Tab again" behaviour. The `current-workspace-only` setting doesn't help because these loops operate on the raw `window_group`, not the switcher's window list.

## Fix

Scope both loops to the active workspace (using the same `get_workspace() === currentWorkspace` guard already used further down in `animateClosed`). Windows on other workspaces are simply left alone, so mutter keeps managing them normally — no ghosts, and nothing disappears when you switch to those workspaces.

## Testing

Tested on GNOME Shell 50.1 / Wayland (Ubuntu 26.04). Reproduced the ghosting reliably before the change; with the patch applied and after a re-login, the ghosts are gone and windows on other workspaces still show up correctly when switching to them. Behaviour on a single workspace is unchanged.